### PR TITLE
Mark nodeplugin DaemonSet as system-node-critical

### DIFF
--- a/deploy/kubernetes/1.20/csi-nodeplugin-rclone.yaml
+++ b/deploy/kubernetes/1.20/csi-nodeplugin-rclone.yaml
@@ -17,6 +17,11 @@ spec:
       serviceAccountName: csi-nodeplugin-rclone
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      # The rclone process serves every FUSE mount on the node; if this pod is
+      # evicted under node-pressure all mounts go "Transport endpoint is not
+      # connected" and only consumer-pod recreation heals them. Mark as
+      # node-critical so kubelet doesn't pick it as an eviction victim.
+      priorityClassName: system-node-critical
       containers:
         - name: node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0


### PR DESCRIPTION
## Summary

Add `priorityClassName: system-node-critical` to the `csi-nodeplugin-rclone` DaemonSet pod spec.

## Why

The rclone process in each nodeplugin pod is the FUSE server for every rclone volume mounted on the node. If kubelet evicts the pod under node-pressure (for example when `imagefs.available` crosses the eviction threshold), the rclone process dies and every FUSE mount it was serving goes `Transport endpoint is not connected` in every consumer pod. A freshly spawned replacement nodeplugin pod does **not** adopt the orphaned mounts — it only services new `NodePublishVolume` calls. Consumer pods stay broken until they are recreated.

At `priority: 0` with no priority class, the DaemonSet is one of the first things kubelet picks off under pressure. `system-node-critical` is the intended class for node-local infrastructure (CNI, CSI, kube-proxy) and prevents that.

Resource requests on the pod are tiny (10m CPU, 0.5-1 Gi memory), so the cost of marking it node-critical is negligible.

## Test plan

- [x] Apply manifest, verify `kubectl -n csi-rclone get pod -o jsonpath='{.items[*].spec.priorityClassName}'` reports `system-node-critical`
- [ ] Induce node-pressure on a test node and confirm the nodeplugin pod is no longer selected for eviction